### PR TITLE
feat: POS 주문 상태 관련 API 연동

### DIFF
--- a/src/components/pos/PosOrderDetailModal.jsx
+++ b/src/components/pos/PosOrderDetailModal.jsx
@@ -4,8 +4,11 @@ import { orderAPI } from '../../services/orderAPI';
 import { ORDER_STATUS, ORDER_STATUS_LABEL } from '../../constants/orderTypes';
 import Button from '../basic/Button';
 import TextInput from '../basic/TextInput';
+import { useToast } from '../../contexts/ToastContext';
 
 export const PosOrderDetailModal = ({ orderId, onClose }) => {
+  const { addToast } = useToast();
+
   const [order, setOrder] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -17,7 +20,6 @@ export const PosOrderDetailModal = ({ orderId, onClose }) => {
     try {
       setLoading(true);
       const response = await orderAPI.getOrderDetail(orderId);
-      console.log('Fetched order detail:', response);
       setOrder(response);
       setError(null);
     } catch (err) {
@@ -46,7 +48,7 @@ export const PosOrderDetailModal = ({ orderId, onClose }) => {
             alert('거절 사유를 입력해주세요.');
             return;
           }
-          response = await orderAPI.rejectOrder(orderId, rejectReason);
+          response = await orderAPI.rejectOrder({ orderId, reason: rejectReason });
           break;
         case 'ready':
           response = await orderAPI.markOrderAsReady(orderId);
@@ -60,7 +62,10 @@ export const PosOrderDetailModal = ({ orderId, onClose }) => {
       }
     } catch (err) {
       console.error('Failed to process order:', err);
-      alert('주문 처리 중 오류가 발생했습니다.');
+      addToast({
+        message: '주문 처리 중 오류가 발생했습니다.',
+        type: 'error'
+      });
     }
   };
 

--- a/src/components/pos/PosOrderDetailModal.jsx
+++ b/src/components/pos/PosOrderDetailModal.jsx
@@ -121,11 +121,11 @@ export const PosOrderDetailModal = ({ orderId, onClose }) => {
             </div>
             <div className={styles.infoRow}>
               <span>주문 상태:</span>
-              <span>{ORDER_STATUS_LABEL[order.orderStatus]}</span>
+              <span>&nbsp;{ORDER_STATUS_LABEL[order.orderStatus]}</span>
             </div>
             <div className={styles.infoRow}>
               <span>주문 시간:</span>
-              <span>{new Date(order.orderTime).toLocaleString()}</span>
+              <span>&nbsp;{new Date(order.orderTime).toLocaleString()}</span>
             </div>
           </div>
 

--- a/src/components/pos/PosOrderDetailModal.jsx
+++ b/src/components/pos/PosOrderDetailModal.jsx
@@ -17,7 +17,8 @@ export const PosOrderDetailModal = ({ orderId, onClose }) => {
     try {
       setLoading(true);
       const response = await orderAPI.getOrderDetail(orderId);
-      setOrder(response.data);
+      console.log('Fetched order detail:', response);
+      setOrder(response);
       setError(null);
     } catch (err) {
       setError('주문 정보를 불러오는데 실패했습니다.');
@@ -102,33 +103,38 @@ export const PosOrderDetailModal = ({ orderId, onClose }) => {
           <div className={styles.orderInfo}>
             <div className={styles.infoRow}>
               <span>주문 번호:</span>
-              <span>#{order.orderId}</span>
+              <span>&nbsp;{order.orderNumber}</span>
             </div>
             <div className={styles.infoRow}>
               <span>주문 상태:</span>
-              <span>{ORDER_STATUS_LABEL[order.status]}</span>
+              <span>{ORDER_STATUS_LABEL[order.orderStatus]}</span>
             </div>
             <div className={styles.infoRow}>
               <span>주문 시간:</span>
-              <span>{new Date(order.createdAt).toLocaleString()}</span>
+              <span>{new Date(order.orderTime).toLocaleString()}</span>
             </div>
           </div>
 
           <div className={styles.itemList}>
             <h4>주문 항목</h4>
-            {order.items.map((item, index) => (
+            {order.menuItems.map((item, index) => (
               <div key={`${order.orderId}-${item.name}-${item.quantity}-${index}`} className={styles.item}>
                 <div className={styles.itemInfo}>
-                  <span className={styles.itemName}>{item.name}</span>
+                  <span className={styles.itemName}>{item.menuName}</span>
                   <span className={styles.itemQuantity}>x {item.quantity}</span>
                 </div>
-                {item.options?.map((option, optIndex) => (
-                  <div key={`${order.orderId}-${item.name}-${option.name}-${option.value}`} className={styles.itemOption}>
-                    - {option.name}: {option.value}
+                {item.options?.map((optionGroup, ogIndex) => (
+                  <div key={`${order.orderId}-${item.menuName}-${optionGroup.optionGroupName}-${ogIndex}`} className={styles.itemOption}>
+                    <div>{optionGroup.optionGroupName}</div>
+                    {optionGroup.options.map((option, optIndex) => (
+                      <div key={`${order.orderId}-${item.menuName}-${optionGroup.optionGroupName}-${option.optionName}-${optIndex}`}>
+                        - {option.optionName} ({option.optionPrice.toLocaleString()}원)
+                      </div>
+                    ))}
                   </div>
                 ))}
                 <div className={styles.itemPrice}>
-                  {(item.price * item.quantity).toLocaleString()}원
+                  {(item.menuPrice).toLocaleString()}원
                 </div>
               </div>
             ))}
@@ -136,7 +142,7 @@ export const PosOrderDetailModal = ({ orderId, onClose }) => {
 
           <div className={styles.totalPrice}>
             <span>총 결제 금액</span>
-            <span>{order.totalAmount.toLocaleString()}원</span>
+            <span>{order.totalPrice.toLocaleString()}원</span>
           </div>
 
           {order.status === ORDER_STATUS.PENDING && (

--- a/src/components/pos/PosOrderDetailModal.jsx
+++ b/src/components/pos/PosOrderDetailModal.jsx
@@ -116,7 +116,7 @@ export const PosOrderDetailModal = ({ orderId, onClose }) => {
           </div>
 
           <div className={styles.itemList}>
-            <h4>주문 항목</h4>
+            <h4>주문 메뉴</h4>
             {order.menuItems.map((item, index) => (
               <div key={`${order.orderId}-${item.name}-${item.quantity}-${index}`} className={styles.item}>
                 <div className={styles.itemInfo}>
@@ -145,7 +145,7 @@ export const PosOrderDetailModal = ({ orderId, onClose }) => {
             <span>{order.totalPrice.toLocaleString()}원</span>
           </div>
 
-          {order.status === ORDER_STATUS.PENDING && (
+          {order.orderStatus === ORDER_STATUS.WAITING && (
             <div className={styles.actions}>
               <div className={styles.inputGroup}>
                 <TextInput
@@ -174,18 +174,6 @@ export const PosOrderDetailModal = ({ orderId, onClose }) => {
                   주문 거절
                 </Button>
               </div>
-            </div>
-          )}
-
-          {order.status === ORDER_STATUS.ACCEPTED && (
-            <div className={styles.actions}>
-              <Button 
-                onClick={() => handleOrderAction('ready')}
-                variant="success"
-                fullWidth
-              >
-                조리 완료
-              </Button>
             </div>
           )}
         </div>

--- a/src/components/pos/PosOrderDetailModal.module.css
+++ b/src/components/pos/PosOrderDetailModal.module.css
@@ -191,7 +191,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 16px 20px;
+  padding: 8px 20px;
   border-bottom: 1px solid #eee;
 }
 
@@ -204,10 +204,12 @@
 .closeButton {
   background: none;
   border: none;
+  width: 40px;
+  height: 40px;
   font-size: 24px;
   color: #666;
   cursor: pointer;
-  padding: 0;
+  padding: 6px 8px 10px;
   line-height: 1;
 }
 

--- a/src/components/pos/PosOrderDetailModal.module.css
+++ b/src/components/pos/PosOrderDetailModal.module.css
@@ -232,11 +232,6 @@
 .infoRow {
   display: flex;
   justify-content: space-between;
-  margin-bottom: 8px;
-}
-
-.infoRow:last-child {
-  margin-bottom: 0;
 }
 
 .itemList {
@@ -244,7 +239,7 @@
 }
 
 .itemList h4 {
-  margin: 0 0 16px 0;
+  margin: 0 3px 16px;
   color: #333;
 }
 

--- a/src/components/pos/PosOrderList.jsx
+++ b/src/components/pos/PosOrderList.jsx
@@ -6,7 +6,6 @@ import { ORDER_STATUS, ORDER_STATUS_COLOR, ORDER_STATUS_LABEL, ORDER_FILTERS } f
 import { orderAPI } from '../../services/orderAPI';
 import { PosOrderDetailModal } from './PosOrderDetailModal';
 import { useToast } from '../../contexts/ToastContext';
-import apiClient from '../../services/apiClient';
 
 export const PosOrderList = ({ storeId, onOrdersUpdate }) => {
   const [orders, setOrders] = useState([]);
@@ -23,7 +22,7 @@ export const PosOrderList = ({ storeId, onOrdersUpdate }) => {
       setLoading(true);
       const response = await orderAPI.getOrders(storeId);
       const newOrders = response.data.orders || [];
-      
+
       // 새로운 주문 확인
       const prevOrderIds = new Set(previousOrdersRef.current.map(order => order.id));
       const newPendingOrders = newOrders.filter(
@@ -178,7 +177,7 @@ export const PosOrderList = ({ storeId, onOrdersUpdate }) => {
   // 주문 상태별 버튼 렌더링
   const getOrderActions = (order) => {
     switch (order.status) {
-      case ORDER_STATUS.PENDING:
+      case ORDER_STATUS.WAITING:
         return (
           <>
             <Button onClick={() => handleOrderAction(order.orderId || order.id, 'accept')} variant="primary">수락</Button>
@@ -229,12 +228,12 @@ export const PosOrderList = ({ storeId, onOrdersUpdate }) => {
         <div className={styles.orderList}>
           {filteredOrders.map((order) => (
             <div 
-              key={`order-${order.orderId}-${order.status}`} 
+              key={`order-${order.orderNumber}-${order.status}`} 
               className={styles.orderCard}
               onClick={() => setSelectedOrderId(order.orderId)}
             >
               <div className={styles.orderHeader}>
-                <span className={styles.orderId}>주문 #{order.orderId}</span>
+                <span className={styles.orderId}>주문 {order.orderNumber}</span>
                 <span 
                   className={styles.status}
                   style={{ backgroundColor: ORDER_STATUS_COLOR[order.status] }}
@@ -244,9 +243,9 @@ export const PosOrderList = ({ storeId, onOrdersUpdate }) => {
               </div>
               
               <div className={styles.orderItems}>
-                {order.items.map((item, index) => (
-                  <div key={`${order.orderId}-${item.name}-${item.quantity}-${index}`} className={styles.item}>
-                    <span>{item.name}</span>
+                {order.menuItems.map((item, index) => (
+                  <div key={`${order.orderId}-${item.menuName}-${item.quantity}-${index}`} className={styles.item}>
+                    <span>{item.menuName}</span>
                     <span>x {item.quantity}</span>
                   </div>
                 ))}

--- a/src/components/pos/PosOrderList.jsx
+++ b/src/components/pos/PosOrderList.jsx
@@ -51,7 +51,7 @@ export const PosOrderList = ({ storeId, onOrdersUpdate }) => {
   // 필터링된 주문 목록
   const filteredOrders = orders.filter(order => {
     // 배달완료된 주문은 항상 숨김처리
-    if (order.status === ORDER_STATUS.COMPLETED) {
+    if (order.orderStatus === ORDER_STATUS.COMPLETED) {
       return false;
     }
 
@@ -70,7 +70,7 @@ export const PosOrderList = ({ storeId, onOrdersUpdate }) => {
     }
 
     // 필터가 ALL이면 배달완료를 제외한 모든 주문 표시, 아니면 해당 상태의 주문만 표시
-    return filter === 'ALL' || order.status === filter;
+    return filter === 'ALL' || order.orderStatus === filter;
   });
 
   // 주문 상태별 개수 계산 (오늘 날짜 기준)
@@ -125,9 +125,8 @@ export const PosOrderList = ({ storeId, onOrdersUpdate }) => {
           setSelectedOrderId(orderId); // 거절 사유 입력을 위해 모달 열기
           return;
         case 'startCooking':
-          response = await orderAPI.startCooking(orderId);
-          successMessage = '조리가 시작되었습니다.';
-          break;
+          setSelectedOrderId(orderId); // 조리 예상 시간 입력을 위해 모달 열기
+          return;
         case 'ready':
           response = await orderAPI.markOrderAsReady(orderId);
           successMessage = '조리가 완료되었습니다.';
@@ -213,7 +212,7 @@ export const PosOrderList = ({ storeId, onOrdersUpdate }) => {
         <ComboBox
           options={ORDER_FILTERS}
           value={filter}
-          onChange={(value) => setFilter(value)}
+          onChange={(e) => setFilter(e.target.value)}
           className={styles.filter}
         />
       </div>
@@ -236,7 +235,7 @@ export const PosOrderList = ({ storeId, onOrdersUpdate }) => {
                   className={styles.status}
                   style={{ backgroundColor: ORDER_STATUS_COLOR[order.orderStatus] }}
                 >
-                  {ORDER_STATUS_LABEL[order.status]}
+                  {ORDER_STATUS_LABEL[order.orderStatus]}
                 </span>
               </div>
               

--- a/src/components/pos/PosOrderList.jsx
+++ b/src/components/pos/PosOrderList.jsx
@@ -50,8 +50,9 @@ export const PosOrderList = ({ storeId, onOrdersUpdate }) => {
 
   // 필터링된 주문 목록
   const filteredOrders = orders.filter(order => {
-    // 배달완료된 주문은 항상 숨김처리
-    if (order.orderStatus === ORDER_STATUS.COMPLETED) {
+    // 주문완료 주문만 보는 경우가 아니면 주문완료된 주문은 항상 숨김처리
+    if (filter !== ORDER_STATUS.COMPLETED &&
+        order.orderStatus === ORDER_STATUS.COMPLETED) {
       return false;
     }
 
@@ -69,7 +70,7 @@ export const PosOrderList = ({ storeId, onOrdersUpdate }) => {
       return false;
     }
 
-    // 필터가 ALL이면 배달완료를 제외한 모든 주문 표시, 아니면 해당 상태의 주문만 표시
+    // 필터가 ALL이면 주문완료를 제외한 모든 주문 표시, 아니면 해당 상태의 주문만 표시
     return filter === 'ALL' || order.orderStatus === filter;
   });
 
@@ -131,10 +132,6 @@ export const PosOrderList = ({ storeId, onOrdersUpdate }) => {
           response = await orderAPI.markOrderAsReady(orderId);
           successMessage = '조리가 완료되었습니다.';
           break;
-        case 'startDelivery':
-          response = await orderAPI.startDelivery(orderId);
-          successMessage = '배달이 시작되었습니다.';
-          break;
         default:
           throw new Error('Invalid action');
       }
@@ -188,10 +185,9 @@ export const PosOrderList = ({ storeId, onOrdersUpdate }) => {
       case ORDER_STATUS.COOKED:
         return <p>배차 대기 중</p>;
       case ORDER_STATUS.RIDER_READY:
+        return <p>라이더 이동 중</p>;
       case ORDER_STATUS.ARRIVED:
-        return (
-          <Button onClick={() => handleOrderAction(order.orderId || order.id, 'startDelivery')} variant="primary">음식전달 완료</Button>
-        );
+        return <p>라이더 도착</p>;
       case ORDER_STATUS.DELIVERING:
         return <p>배달 중</p>;
       case ORDER_STATUS.DELIVERED:

--- a/src/components/pos/PosOrderList.jsx
+++ b/src/components/pos/PosOrderList.jsx
@@ -119,13 +119,11 @@ export const PosOrderList = ({ storeId, onOrdersUpdate }) => {
 
       switch (action) {
         case 'accept':
-          response = await orderAPI.acceptOrder(orderId);
-          successMessage = '주문이 수락되었습니다.';
-          break;
+          setSelectedOrderId(orderId); // 예상 조리 시간 입력을 위해 모달 열기
+          return;
         case 'reject':
-          response = await orderAPI.rejectOrder(orderId);
-          successMessage = '주문이 거절되었습니다.';
-          break;
+          setSelectedOrderId(orderId); // 거절 사유 입력을 위해 모달 열기
+          return;
         case 'startCooking':
           response = await orderAPI.startCooking(orderId);
           successMessage = '조리가 시작되었습니다.';
@@ -264,7 +262,10 @@ export const PosOrderList = ({ storeId, onOrdersUpdate }) => {
       {selectedOrderId && (
         <PosOrderDetailModal
           orderId={selectedOrderId}
-          onClose={() => setSelectedOrderId(null)}
+          onClose={() => {
+            setSelectedOrderId(null);
+            fetchOrders();
+          }}
         />
       )}
     </div>

--- a/src/components/pos/PosOrderList.jsx
+++ b/src/components/pos/PosOrderList.jsx
@@ -126,21 +126,17 @@ export const PosOrderList = ({ storeId, onOrdersUpdate }) => {
           response = await orderAPI.rejectOrder(orderId);
           successMessage = '주문이 거절되었습니다.';
           break;
+        case 'startCooking':
+          response = await orderAPI.startCooking(orderId);
+          successMessage = '조리가 시작되었습니다.';
+          break;
         case 'ready':
           response = await orderAPI.markOrderAsReady(orderId);
           successMessage = '조리가 완료되었습니다.';
           break;
-        case 'requestDelivery':
-          response = await orderAPI.requestDelivery(orderId);
-          successMessage = '배차가 신청되었습니다.';
-          break;
-        case 'assignDelivery':
-          response = await orderAPI.assignDelivery(orderId);
-          successMessage = '배차가 완료되었습니다.';
-          break;
-        case 'completeDelivery':
-          response = await orderAPI.completeDelivery(orderId);
-          successMessage = '배달이 완료되었습니다.';
+        case 'startDelivery':
+          response = await orderAPI.startDelivery(orderId);
+          successMessage = '배달이 시작되었습니다.';
           break;
         default:
           throw new Error('Invalid action');
@@ -176,33 +172,37 @@ export const PosOrderList = ({ storeId, onOrdersUpdate }) => {
 
   // 주문 상태별 버튼 렌더링
   const getOrderActions = (order) => {
-    switch (order.status) {
+    switch (order.orderStatus) {
       case ORDER_STATUS.WAITING:
         return (
-          <>
+          <div className={styles.actionsFlex}>
             <Button onClick={() => handleOrderAction(order.orderId || order.id, 'accept')} variant="primary">수락</Button>
             <Button onClick={() => handleOrderAction(order.orderId || order.id, 'reject')} variant="danger">거절</Button>
-          </>
+          </div>
         );
       case ORDER_STATUS.ACCEPTED:
         return (
+          <Button onClick={() => handleOrderAction(order.orderId || order.id, 'startCooking')} variant="primary">조리시작</Button>
+        );
+      case ORDER_STATUS.COOKING:
+        return (
           <Button onClick={() => handleOrderAction(order.orderId || order.id, 'ready')} variant="primary">조리완료</Button>
         );
-      case ORDER_STATUS.READY:
+      case ORDER_STATUS.COOKED:
+        return <p>배차 대기 중</p>;
+      case ORDER_STATUS.RIDER_READY:
+      case ORDER_STATUS.ARRIVED:
         return (
-          <Button onClick={() => handleOrderAction(order.orderId || order.id, 'requestDelivery')} variant="primary">배차신청</Button>
+          <Button onClick={() => handleOrderAction(order.orderId || order.id, 'startDelivery')} variant="primary">음식전달 완료</Button>
         );
-      case ORDER_STATUS.DELIVERY_REQUESTED:
-        return (
-          <Button onClick={() => handleOrderAction(order.orderId || order.id, 'assignDelivery')} variant="primary">배차완료</Button>
-        );
-      case ORDER_STATUS.DELIVERY_ASSIGNED:
-        return (
-          <Button onClick={() => handleOrderAction(order.orderId || order.id, 'completeDelivery')} variant="success">배달완료</Button>
-        );
+      case ORDER_STATUS.DELIVERING:
+        return <p>배달 중</p>;
+      case ORDER_STATUS.DELIVERED:
+        return <p>배달 완료</p>;
       case ORDER_STATUS.COMPLETED:
+        return <p>주문 완료</p>;
       case ORDER_STATUS.REJECTED:
-        return null; // 완료/거절된 주문은 액션 버튼 없음
+        return <p>주문 거절됨</p>;
       default:
         return null;
     }
@@ -236,7 +236,7 @@ export const PosOrderList = ({ storeId, onOrdersUpdate }) => {
                 <span className={styles.orderId}>주문 {order.orderNumber}</span>
                 <span 
                   className={styles.status}
-                  style={{ backgroundColor: ORDER_STATUS_COLOR[order.status] }}
+                  style={{ backgroundColor: ORDER_STATUS_COLOR[order.orderStatus] }}
                 >
                   {ORDER_STATUS_LABEL[order.status]}
                 </span>

--- a/src/components/pos/PosOrderList.module.css
+++ b/src/components/pos/PosOrderList.module.css
@@ -127,6 +127,7 @@
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
+  width: 100%;
 }
 
 .loading {
@@ -148,6 +149,16 @@
   background-color: white;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.actionsFlex {
+  display: flex;
+  gap: 12px;
+  flex-direction: row;
+  width: 100%;
+}
+.actionsFlex> button {
+  flex: 1;
 }
 
 /* 태블릿 */

--- a/src/components/pos/PosStatsDashboard.jsx
+++ b/src/components/pos/PosStatsDashboard.jsx
@@ -45,27 +45,31 @@ const PosStatsDashboard = ({ orders = [] }) => {
     });
 
     // 상태별 주문 수 계산
-    const pendingOrders = todayOrders.filter(order => order.status === ORDER_STATUS.PENDING).length;
+    const pendingOrders = todayOrders.filter(order => order.orderStatus === ORDER_STATUS.WAITING).length;
     const processingOrders = todayOrders.filter(order => 
-      order.status === ORDER_STATUS.ACCEPTED || 
-      order.status === ORDER_STATUS.READY || 
-      order.status === ORDER_STATUS.DELIVERY_REQUESTED
+      order.orderStatus === ORDER_STATUS.ACCEPTED ||
+      order.orderStatus === ORDER_STATUS.COOKING ||
+      order.orderStatus === ORDER_STATUS.COOKED ||
+      order.orderStatus === ORDER_STATUS.RIDER_READY ||
+      order.orderStatus === ORDER_STATUS.ARRIVED
     ).length;
     const completedOrders = todayOrders.filter(order => 
-      order.status === ORDER_STATUS.DELIVERY_ASSIGNED || 
-      order.status === ORDER_STATUS.COMPLETED
+      order.orderStatus === ORDER_STATUS.DELIVERING || 
+      order.orderStatus === ORDER_STATUS.DELIVERED || 
+      order.orderStatus === ORDER_STATUS.COMPLETED
     ).length;
 
-
-    
 
 
     // 총 매출액 계산 (배차완료 이상 상태의 주문만)
     const completedOrdersData = todayOrders.filter(order => 
-      order.status === ORDER_STATUS.DELIVERY_ASSIGNED || 
-      order.status === ORDER_STATUS.COMPLETED
+      order.orderStatus === ORDER_STATUS.RIDER_READY ||
+      order.orderStatus === ORDER_STATUS.ARRIVED ||
+      order.orderStatus === ORDER_STATUS.DELIVERING ||
+      order.orderStatus === ORDER_STATUS.DELIVERED || 
+      order.orderStatus === ORDER_STATUS.COMPLETED
     );
-    const totalSales = completedOrdersData.reduce((sum, order) => sum + (order.totalAmount || 0), 0);
+    const totalSales = completedOrdersData.reduce((sum, order) => sum + (order.totalPrice || 0), 0);
 
     // 평균 주문금액 계산
     const averageOrderAmount = completedOrdersData.length > 0

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -34,12 +34,12 @@ export const API_ENDPOINTS = {
   ORDERS: {
     LIST: (storeId) => `/owner/${storeId}/orders`,  // GET (주문 목록 조회)
     DETAIL: (orderId) => `/owner/orders/${orderId}`, // GET (주문 상세 조회)
-    ACCEPT: (orderId) => `/owner/orders/${orderId}/accept`, // POST (주문 수락)
-    REJECT: (orderId) => `/owner/orders/${orderId}/reject`, // POST (주문 거절)
-    READY: (orderId) => `/orders/${orderId}/ready`, // POST (조리 완료)
-    COOKTIME: (orderId) => `/orders/${orderId}/cooktime`, // POST (예상 조리시간 설정)
-    PAUSE: (storeId) => `/orders/${storeId}/pause`, // POST (주문 일시정지)
-    START: (storeId) => `/orders/${storeId}/start`, // POST (주문 재개)
+    ACCEPT: (orderId) => `/owner/orders/${orderId}/accept`, // PUT (주문 수락)
+    REJECT: (orderId) => `/owner/orders/${orderId}/reject`, // PUT (주문 거절)
+    COOKTIME: (orderId) => `/owner/orders/${orderId}/cooktime`, // PUT (예상 조리시간 설정, 조리 시작)
+    READY: (orderId) => `/owner/orders/${orderId}/ready`, // POST (조리 완료)
+    PAUSE: (storeId) => `/owner/orders/${storeId}/pause`, // POST (주문 일시정지)
+    START: (storeId) => `/owner/orders/${storeId}/start`, // POST (주문 재개)
     // 통계 관련
     STATS: {
       DAILY: (storeId) => `/daily_stats/${storeId}`, // GET (일간 통계)

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -34,8 +34,8 @@ export const API_ENDPOINTS = {
   ORDERS: {
     LIST: (storeId) => `/owner/${storeId}/orders`,  // GET (주문 목록 조회)
     DETAIL: (orderId) => `/owner/orders/${orderId}`, // GET (주문 상세 조회)
-    ACCEPT: (orderId) => `/orders/${orderId}/accept`, // POST (주문 수락)
-    REJECT: (orderId) => `/orders/${orderId}/reject`, // POST (주문 거절)
+    ACCEPT: (orderId) => `/owner/orders/${orderId}/accept`, // POST (주문 수락)
+    REJECT: (orderId) => `/owner/orders/${orderId}/reject`, // POST (주문 거절)
     READY: (orderId) => `/orders/${orderId}/ready`, // POST (조리 완료)
     COOKTIME: (orderId) => `/orders/${orderId}/cooktime`, // POST (예상 조리시간 설정)
     PAUSE: (storeId) => `/orders/${storeId}/pause`, // POST (주문 일시정지)

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -32,8 +32,8 @@ export const API_ENDPOINTS = {
   OWNER: `/owner`,
   // 주문 관련
   ORDERS: {
-    LIST: (storeId) => `/orders?storeId=${storeId}`,  // GET (주문 목록 조회)
-    DETAIL: (orderId) => `/orders/${orderId}`, // GET (주문 상세 조회)
+    LIST: (storeId) => `/owner/${storeId}/orders`,  // GET (주문 목록 조회)
+    DETAIL: (orderId) => `/owner/orders/${orderId}`, // GET (주문 상세 조회)
     ACCEPT: (orderId) => `/orders/${orderId}/accept`, // POST (주문 수락)
     REJECT: (orderId) => `/orders/${orderId}/reject`, // POST (주문 거절)
     READY: (orderId) => `/orders/${orderId}/ready`, // POST (조리 완료)

--- a/src/constants/orderTypes.js
+++ b/src/constants/orderTypes.js
@@ -1,14 +1,15 @@
 // 주문 상태 enum
 export const ORDER_STATUS = {
   WAITING: 'WAITING',               // 대기중
-  ACCEPTED: 'ACCEPTED',            // 수락됨
-  REJECTED: 'REJECTED',            // 거절됨
-  COOKING: 'COOKING',            // 조리중
-  COOKED: 'COOKED',                // 조리완료
-  RIDER_READY: 'RIDER_READY',      // 배차완료
-  DELIVERING: 'DELIVERING',          // 배달중
-  DELIVERED: 'DELIVERED',            // 배달완료
-  COMPLETED: 'COMPLETED',          // 주문완료
+  ACCEPTED: 'ACCEPTED',             // 수락됨
+  REJECTED: 'REJECTED',             // 거절됨
+  COOKING: 'COOKING',               // 조리중
+  COOKED: 'COOKED',                 // 조리완료
+  RIDER_READY: 'RIDER_READY',       // 배차완료
+  ARRIVED: 'ARRIVED',               // 매장도착
+  DELIVERING: 'DELIVERING',         // 배달중
+  DELIVERED: 'DELIVERED',           // 배달완료
+  COMPLETED: 'COMPLETED',           // 주문완료
 };
 
 // 주문 상태 레이블
@@ -19,6 +20,7 @@ export const ORDER_STATUS_LABEL = {
   [ORDER_STATUS.COOKING]: '조리중',
   [ORDER_STATUS.COOKED]: '조리완료',
   [ORDER_STATUS.RIDER_READY]: '배차완료',
+  [ORDER_STATUS.ARRIVED]: '매장도착',
   [ORDER_STATUS.DELIVERING]: '배달중',
   [ORDER_STATUS.DELIVERED]: '배달완료',
   [ORDER_STATUS.COMPLETED]: '주문완료',
@@ -32,6 +34,7 @@ export const ORDER_STATUS_COLOR = {
   [ORDER_STATUS.COOKING]: '#FF9800',   // 연한 주황색
   [ORDER_STATUS.COOKED]: '#8BC34A',    // 연한 초록색
   [ORDER_STATUS.RIDER_READY]: '#2196F3',     // 파란색
+  [ORDER_STATUS.ARRIVED]: '#3F51B5',   // 진한 파란색
   [ORDER_STATUS.DELIVERING]: '#FF5722',   // 진한 주황색
   [ORDER_STATUS.DELIVERED]: '#9E9E9E', // 회색
   [ORDER_STATUS.COMPLETED]: '#9E9E9E', // 회색
@@ -40,11 +43,12 @@ export const ORDER_STATUS_COLOR = {
 // 주문 필터 옵션
 export const ORDER_FILTERS = [
   { value: 'ALL', label: '전체' },
-  { value: ORDER_STATUS.WAITING, label: '대기중' },
+  { value: ORDER_STATUS.WAITING, label: '수락 대기중' },
   { value: ORDER_STATUS.ACCEPTED, label: '수락됨' },
   { value: ORDER_STATUS.COOKING, label: '조리중' },
   { value: ORDER_STATUS.COOKED, label: '조리완료' },
   { value: ORDER_STATUS.RIDER_READY, label: '배차완료' },
+  { value: ORDER_STATUS.ARRIVED, label: '매장도착' },
   { value: ORDER_STATUS.DELIVERING, label: '배달중' },
   { value: ORDER_STATUS.DELIVERED, label: '배달완료' },
   { value: ORDER_STATUS.COMPLETED, label: '주문완료' },

--- a/src/constants/orderTypes.js
+++ b/src/constants/orderTypes.js
@@ -1,42 +1,51 @@
 // 주문 상태 enum
 export const ORDER_STATUS = {
-  PENDING: 'PENDING',               // 대기중
+  WAITING: 'WAITING',               // 대기중
   ACCEPTED: 'ACCEPTED',            // 수락됨
   REJECTED: 'REJECTED',            // 거절됨
-  READY: 'READY',                  // 조리완료
-  DELIVERY_REQUESTED: 'DELIVERY_REQUESTED',  // 배차신청
-  DELIVERY_ASSIGNED: 'DELIVERY_ASSIGNED',    // 배차완료
-  COMPLETED: 'COMPLETED',          // 배달완료
+  COOKING: 'COOKING',            // 조리중
+  COOKED: 'COOKED',                // 조리완료
+  RIDER_READY: 'RIDER_READY',      // 배차완료
+  DELIVERING: 'DELIVERING',          // 배달중
+  DELIVERED: 'DELIVERED',            // 배달완료
+  COMPLETED: 'COMPLETED',          // 주문완료
 };
 
 // 주문 상태 레이블
 export const ORDER_STATUS_LABEL = {
-  [ORDER_STATUS.PENDING]: '대기중',
+  [ORDER_STATUS.WAITING]: '대기중',
   [ORDER_STATUS.ACCEPTED]: '수락됨',
   [ORDER_STATUS.REJECTED]: '거절됨',
-  [ORDER_STATUS.READY]: '조리완료',
-  [ORDER_STATUS.DELIVERY_REQUESTED]: '배차신청',
-  [ORDER_STATUS.DELIVERY_ASSIGNED]: '배차완료',
-  [ORDER_STATUS.COMPLETED]: '배달완료',
+  [ORDER_STATUS.COOKING]: '조리중',
+  [ORDER_STATUS.COOKED]: '조리완료',
+  [ORDER_STATUS.RIDER_READY]: '배차완료',
+  [ORDER_STATUS.DELIVERING]: '배달중',
+  [ORDER_STATUS.DELIVERED]: '배달완료',
+  [ORDER_STATUS.COMPLETED]: '주문완료',
 };
 
 // 주문 상태별 색상
 export const ORDER_STATUS_COLOR = {
-  [ORDER_STATUS.PENDING]: '#FFA500',   // 주황색
+  [ORDER_STATUS.WAITING]: '#FFA500',   // 주황색
   [ORDER_STATUS.ACCEPTED]: '#4CAF50',  // 초록색
   [ORDER_STATUS.REJECTED]: '#F44336',  // 빨간색
-  [ORDER_STATUS.READY]: '#2196F3',     // 파란색
-  [ORDER_STATUS.DELIVERY_REQUESTED]: '#9C27B0',  // 보라색
-  [ORDER_STATUS.DELIVERY_ASSIGNED]: '#FF5722',   // 진한 주황색
+  [ORDER_STATUS.COOKING]: '#FF9800',   // 연한 주황색
+  [ORDER_STATUS.COOKED]: '#8BC34A',    // 연한 초록색
+  [ORDER_STATUS.RIDER_READY]: '#2196F3',     // 파란색
+  [ORDER_STATUS.DELIVERING]: '#FF5722',   // 진한 주황색
+  [ORDER_STATUS.DELIVERED]: '#9E9E9E', // 회색
   [ORDER_STATUS.COMPLETED]: '#9E9E9E', // 회색
 };
 
 // 주문 필터 옵션
 export const ORDER_FILTERS = [
   { value: 'ALL', label: '전체' },
-  { value: ORDER_STATUS.PENDING, label: '대기중' },
+  { value: ORDER_STATUS.WAITING, label: '대기중' },
   { value: ORDER_STATUS.ACCEPTED, label: '수락됨' },
-  { value: ORDER_STATUS.READY, label: '조리완료' },
-  { value: ORDER_STATUS.DELIVERY_REQUESTED, label: '배차신청' },
-  { value: ORDER_STATUS.DELIVERY_ASSIGNED, label: '배차완료' },
-]; 
+  { value: ORDER_STATUS.COOKING, label: '조리중' },
+  { value: ORDER_STATUS.COOKED, label: '조리완료' },
+  { value: ORDER_STATUS.RIDER_READY, label: '배차완료' },
+  { value: ORDER_STATUS.DELIVERING, label: '배달중' },
+  { value: ORDER_STATUS.DELIVERED, label: '배달완료' },
+  { value: ORDER_STATUS.COMPLETED, label: '주문완료' },
+];

--- a/src/pages/pos/POS.jsx
+++ b/src/pages/pos/POS.jsx
@@ -39,14 +39,9 @@ const POS = () => {
   // 메트릭 데이터 로드
   const loadMetrics = useCallback(async () => {
     try {
-      const analytics = await POS_API.getPosAnalytics();
-      setMetrics(analytics.metrics || {
-        customerRating: 0,
-        avgCookTime: "0분",
-        cookTimeAccuracy: "0%",
-        pickupTime: "0초",
-        orderAcceptanceRate: "0%"
-      });
+      const analytics = await POS_API.getPosAnalytics({ storeId: currentUser?.storeId });
+      if (analytics)
+        setMetrics(analytics);
     } catch (err) {
       console.error('Failed to load metrics:', err);
     }

--- a/src/pages/users/register/RegisterStepOneUserInfo.module.css
+++ b/src/pages/users/register/RegisterStepOneUserInfo.module.css
@@ -3,8 +3,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100vh;
-  padding: 0 1.5rem; /* 양쪽 여백을 상대값으로 설정 */
+  padding: 2rem 1.5rem; /* 양쪽 여백을 상대값으로 설정 */
   gap: 1.5rem;
   max-width: 480px; /* 로그인 박스 최대 너비 제한 */
   margin: 0 auto; /* 중앙 정렬 */
@@ -47,7 +46,6 @@
 
   button {
     width: 100%;
-    min-width: 280px;
     font-size: 1rem;
     padding: 0.8rem 1rem;
   }

--- a/src/services/orderAPI.js
+++ b/src/services/orderAPI.js
@@ -79,8 +79,14 @@ export const orderAPI = {
   },
 
   // 주문 거절
-  rejectOrder: async (orderId) => {
-    return orderAPI.updateOrderStatus(orderId, ORDER_STATUS.REJECTED);
+  rejectOrder: async ({ orderId, reason }) => {
+    const response = await apiClient.put(API_ENDPOINTS.ORDERS.REJECT(orderId), { reason });
+
+    if (response.data.success) {
+      return response;
+    } else {
+      throw new Error('주문 거절에 실패했습니다.');
+    }
   },
 
   // 조리 완료 처리

--- a/src/services/orderAPI.js
+++ b/src/services/orderAPI.js
@@ -107,7 +107,13 @@ export const orderAPI = {
 
   // 조리 완료 처리
   markOrderAsReady: async (orderId) => {
-    return orderAPI.updateOrderStatus(orderId, ORDER_STATUS.READY);
+    const response = await apiClient.put(API_ENDPOINTS.ORDERS.READY(orderId));
+
+    if (response.data.success) {
+      return response;
+    } else {
+      throw new Error('조리 완료에 실패했습니다.');
+    }
   },
 
   // 주문 일시정지

--- a/src/services/orderAPI.js
+++ b/src/services/orderAPI.js
@@ -75,11 +75,17 @@ export const orderAPI = {
 
   // 주문 수락
   acceptOrder: async (orderId) => {
-    return orderAPI.updateOrderStatus(orderId, ORDER_STATUS.ACCEPTED);
+    // 주문 수락
+    const response = await apiClient.put(API_ENDPOINTS.ORDERS.ACCEPT(orderId));
+    if (response.data.success) {
+      return response;
+    } else {
+      throw new Error('주문 수락에 실패했습니다.');
+    }
   },
 
   // 주문 거절
-  rejectOrder: async ({ orderId, reason }) => {
+  rejectOrder: async (orderId, reason) => {
     const response = await apiClient.put(API_ENDPOINTS.ORDERS.REJECT(orderId), { reason });
 
     if (response.data.success) {
@@ -89,21 +95,20 @@ export const orderAPI = {
     }
   },
 
+  // 조리 시작 (예상 조리 시간 설정 후 상태 변경)
+  startCooking: async (orderId, cookTimeMinutes) => {
+    if (!cookTimeMinutes || cookTimeMinutes <= 0) {
+      throw new Error('유효한 조리 시간을 입력해주세요.');
+    }
+    // 예상 조리 시간 설정
+    const response = await apiClient.put(API_ENDPOINTS.ORDERS.COOKTIME(orderId), { cookTime: cookTimeMinutes });
+    return response.data;
+  },
+
   // 조리 완료 처리
   markOrderAsReady: async (orderId) => {
     return orderAPI.updateOrderStatus(orderId, ORDER_STATUS.READY);
   },
-
-  // 예상 조리 시간 설정
-  setCookTime: withOrderErrorHandling(async (orderId, cookTimeMinutes) => {
-    if (!cookTimeMinutes || cookTimeMinutes <= 0) {
-      throw new Error('유효한 조리 시간을 입력해주세요.');
-    }
-    const response = await apiClient.post(API_ENDPOINTS.ORDERS.COOKTIME(orderId), { 
-      cookTimeMinutes 
-    });
-    return response.data;
-  }, 'SET_COOK_TIME'),
 
   // 주문 일시정지
   pauseOrders: withOrderErrorHandling(async (storeId, pauseDurationMinutes) => {

--- a/src/services/posAPI.js
+++ b/src/services/posAPI.js
@@ -335,8 +335,8 @@ const posAPI = {
   }, 'updatePosSettings'),
 
   // POS 분석 데이터 조회
-  getPosAnalytics: withPosErrorHandling(async () => {
-    const response = await retryApiCall(() => apiClient.get('/pos_analytics'), MAX_RETRIES, RETRY_DELAY);
+  getPosAnalytics: withPosErrorHandling(async ({ storeId }) => {
+    const response = await retryApiCall(() => apiClient.get(`/owner/${storeId}/dashboard`), MAX_RETRIES, RETRY_DELAY);
     return response.data;
   }, 'getPosAnalytics'),
 

--- a/src/services/posAPI.js
+++ b/src/services/posAPI.js
@@ -224,15 +224,15 @@ const updateSettings = (currentData, newSettings, settingsKey = 'settings') => (
 const posAPI = {
   // POS 상태 조회 (타임스탬프 형식 검증 개선)
   getPosStatus: withPosErrorHandling(async () => {
-    const response = await apiClient.get('/pos');
+    // const response = await apiClient.get('/pos');
     
-    // 마이그레이션이 필요한 경우에만 실행
-    const needsMigration = await checkTimestampMigrationNeeded();
-    if (needsMigration) {
-      await fixDatabaseTimestamps();
-    }
+    // // 마이그레이션이 필요한 경우에만 실행
+    // const needsMigration = await checkTimestampMigrationNeeded();
+    // if (needsMigration) {
+    //   await fixDatabaseTimestamps();
+    // }
     
-    return { status: response.data.currentStatus };
+    // return { status: response.data.currentStatus };
   }, 'getPosStatus'),
 
   // POS 상태 업데이트 (확장된 메타데이터 포함)


### PR DESCRIPTION
## #️⃣연관된 이슈
#25 
closes #25

## 📝작업 내용

- [X] 대시보드 조회 API 연동
- [X] 주문 목록 조회 API 연동
- [X] 주문 상세 조회 API 연동
- [X] 주문 거절 API 연동
- [X] 주문 수락 API 연동
- [X] 예상 조리시간 설정 API 연동
- [X] 조리 완료 API 연동

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/a30a7912-feed-41ee-818b-caf81ee1a6a7)

## 💬리뷰 요구사항(선택)

기본적인 주문 프로세스 상태와 관련된 API 연동은 완료했습니다.
